### PR TITLE
Sawyer recommendation navbar

### DIFF
--- a/.env.SAMPLE
+++ b/.env.SAMPLE
@@ -1,0 +1,3 @@
+GOOGLE_CLIENT_ID=see-instructions-in-readme
+GOOGLE_CLIENT_SECRET=see-instructions-in-readme
+ADMIN_EMAILS=phtcon@ucsb.edu

--- a/.env.SAMPLE
+++ b/.env.SAMPLE
@@ -1,3 +1,0 @@
-GOOGLE_CLIENT_ID=see-instructions-in-readme
-GOOGLE_CLIENT_SECRET=see-instructions-in-readme
-ADMIN_EMAILS=phtcon@ucsb.edu

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -74,6 +74,13 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                   </NavDropdown>
                 )
               }
+              {
+                hasRole(currentUser, "ROLE_USER") && (
+                  <NavDropdown title="Recommendation" id="appnavbar-recommendation-dropdown" data-testid="appnavbar-recommendation-dropdown" >
+                    <NavDropdown.Item as={Link} to="/recommendation/list">List Recommendations</NavDropdown.Item>
+                  </NavDropdown>
+                )
+              }
             </Nav>
 
             <Nav className="ml-auto">

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -77,7 +77,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
               {
                 hasRole(currentUser, "ROLE_USER") && (
                   <NavDropdown title="Recommendation" id="appnavbar-recommendation-dropdown" data-testid="appnavbar-recommendation-dropdown" >
-                    <NavDropdown.Item as={Link} to="/recommendation/list">List Recommendations</NavDropdown.Item>
+                    <NavDropdown.Item as={Link} to="/recommendation/list" data-testid="appnavbar-recommendation-list">List Recommendations</NavDropdown.Item>
                   </NavDropdown>
                 )
               }

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -236,6 +236,30 @@ describe("AppNavbar tests", () => {
         await waitFor( () => expect(getByTestId(/appnavbar-dining-commons-list/)).toBeInTheDocument() );
 
     });
+
+    test("renders the recommendation menu correctly for a user", async () => {
+
+        const currentUser = currentUserFixtures.userOnly;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        const {getByTestId  } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByTestId("appnavbar-recommendation-dropdown")).toBeInTheDocument());
+        const dropdown = getByTestId("appnavbar-recommendation-dropdown");
+        const aElement = dropdown.querySelector("a");
+        expect(aElement).toBeInTheDocument();
+        aElement?.click();
+        await waitFor( () => expect(getByTestId(/appnavbar-recommendation-list/)).toBeInTheDocument() );
+
+    });
    
 });
 


### PR DESCRIPTION
# Overview

This PR adds the Recommendation tab to the Navbar. When clicked, the Recommendations List option appears.

As a regular user, you can now see the Recommendation tab in the drop-down menu. This allows you to access the List Recommendations page.

# Issues Addressed

Closes #6 

# Details
![image](https://user-images.githubusercontent.com/46574397/168931361-71339052-7528-43b7-a59e-96d65cbd68d3.png)

# Test Plan (for interactive testing)

1. After logging in at the home page, the Recommendation tab appears in the Nav Bar
2. Clicking on the tab opens a drop-down menu with the option 'List Recommendations'
