### PR TITLE
Robert articletable storybook component

### DIFF
--- a/frontend/src/stories/components/Article/ArticleTable.stories.js
+++ b/frontend/src/stories/components/Article/ArticleTable.stories.js
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import ArticleTable from "main/components/Article/ArticleTable";
+import { articleFixtures } from 'fixtures/articleFixtures';
+
+export default {
+    title: 'components/Article/ArticleTable',
+    component: ArticleTable
+};
+
+const Template = (args) => {
+    return (
+        <ArticleTable {...args} />
+    )
+};
+
+export const Empty = Template.bind({});
+
+Empty.args = {
+    article: []
+};
+
+export const ThreeArticles = Template.bind({});
+
+ThreeArticles.args = {
+    article: articleFixtures.threeArticles
+};
+
+


### PR DESCRIPTION
# Overview

This PR adds the article table component to storybook. This is needed to test out the article table component without the backend. 

# Issues Addressed

Closes #13 

# Link to Storybook

[Storybook - ArticleTable Component](https://ucsb-cs156-s22.github.io/team03-s22-4pm-1-docs-qa/storybook-qa/Robert-articletable-storybook-component/)

# Details

![Screenshot_20220517_182745](https://user-images.githubusercontent.com/59896939/168938494-2277f872-4139-4748-87df-cd1b106b5741.png)

# Test Plan (for interactive testing) (Storybook only)
 
1. Proceed to the provided [Storybook](https://ucsb-cs156-s22.github.io/team03-s22-4pm-1-docs-qa/storybook-qa/Robert-articletable-storybook-component/) link and see the "Article" dropdown under the section of "Components".
2. Select the "ArticleTable" dropdown and checkout each of the example fixtures. 
3. The "Empty" example should be empty and only contain the labels.
4. The "ThreeArticles" example should have three example entries.
